### PR TITLE
Fix for 3.8

### DIFF
--- a/hide-dash@zacbarton.com/extension.js
+++ b/hide-dash@zacbarton.com/extension.js
@@ -45,7 +45,7 @@ HideDash.prototype = {
 	hide: function() {
 		// global.log("show dash");
 		Main.overview._dash.actor.hide();
-		Main.overview._viewSelector.actor.set_x(0);
+		Main.overview._viewSelector.actor.set_x_align(0);
 		Main.overview._viewSelector.actor.set_width(Main.overview._group.get_width());
 		Main.overview._viewSelector.actor.queue_redraw();
 	},
@@ -53,7 +53,7 @@ HideDash.prototype = {
 	show: function() {
 		// global.log("hide dash");
 		Main.overview._dash.actor.show();
-		Main.overview._viewSelector.actor.set_x(this.old_x);
+		Main.overview._viewSelector.actor.set_x_align(this.old_x);
 		Main.overview._viewSelector.actor.set_width(this.old_width);
 		Main.overview._viewSelector.actor.queue_redraw();
 	}

--- a/hide-dash@zacbarton.com/metadata.json
+++ b/hide-dash@zacbarton.com/metadata.json
@@ -1,13 +1,10 @@
 {
 	"shell-version": [
-		"3.2",
-		"3.3.1", "3.3.2", "3.3.3", "3.3.4",
-		"3.4",
-		"3.6"
+		"3.8"
 	], 
 	"uuid": "hide-dash@zacbarton.com",
 	"name": "Hide Dash",
 	"description": "Hide the dash from the activities overview",
 	"url": "https://github.com/zacbarton/gnome-shell-extension-hide-dash",
-	"version": 1
+	"version": 8
 }


### PR DESCRIPTION
This adds 3.8 support, fixing issue #3. Note that this new version only works on 3.8, but that's OK, because older versions on extensions.gnome.org still support older versions of GNOME, and multiple versions can be hosted on gnome.org simultaneously.
